### PR TITLE
feat: 게시글 작성 구현 - 이미지 업로드 및 텍스트 상자

### DIFF
--- a/src/components/Textarea/Textarea.jsx
+++ b/src/components/Textarea/Textarea.jsx
@@ -1,0 +1,24 @@
+import React, { useRef } from "react";
+
+const Textarea = () => {
+  const textareaRef = useRef();
+  const handleTextareaResize = (e) => {
+    textareaRef.current.style.height = "auto";
+    textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+  };
+
+  return (
+    <textarea
+      ref={textareaRef}
+      name=""
+      id=""
+      cols="30"
+      rows="1"
+      placeholder="게시글 입력하기..."
+      className="w-[30.4rem] p-[0.2rem] mt-[1.2rem] mb-[1.6rem] ml-[1.2rem] align-bottom overflow-hidden resize-none focus:outline-none"
+      onChange={handleTextareaResize}
+    ></textarea>
+  );
+};
+
+export default Textarea;

--- a/src/pages/PostCreate/PostCreate.jsx
+++ b/src/pages/PostCreate/PostCreate.jsx
@@ -5,7 +5,7 @@ import { HeaderSave } from "../../share/HeaderBind";
 const PostCreate = () => {
   const myProfile = `${process.env.PUBLIC_URL}/assets/img/profile-man-small.png`;
   const imgUpload = `${process.env.PUBLIC_URL}/assets/img/icon-upload-file.png`;
-  const imgCamcle = `${process.env.PUBLIC_URL}/assets/img/icon-x.png`;
+  const imgCancle = `${process.env.PUBLIC_URL}/assets/img/icon-x.png`;
 
   const [images, setImages] = useState([]);
   const [imageURLs, setImgURLs] = useState([]);
@@ -22,11 +22,8 @@ const PostCreate = () => {
   };
 
   const handleImgCancle = (e) => {
-    console.log(e.target.id);
     const newImageURLs = imageURLs.filter((_, index) => index !== parseInt(e.target.id));
     setImgURLs(newImageURLs);
-    console.log(newImageURLs);
-    console.log(imageURLs);
   };
 
   return (
@@ -47,7 +44,7 @@ const PostCreate = () => {
                   <img src={imgURL} alt="" className="w-[30.4rem] h-[22.8rem] ml-auto object-cover rounded-[10px]" />
                   <button type="button" onClick={handleImgCancle}>
                     <img
-                      src={imgCamcle}
+                      src={imgCancle}
                       id={index}
                       alt=""
                       className="w-[2rem] h-[2rem] absolute top-[1.1rem] right-[1.1rem]"
@@ -68,7 +65,7 @@ const PostCreate = () => {
                   />
                   <button type="button" onClick={handleImgCancle}>
                     <img
-                      src={imgCamcle}
+                      src={imgCancle}
                       id={index}
                       alt=""
                       className="w-[1.5rem] h-[1.5rem] absolute top-[1.1rem] right-[1.1rem]"

--- a/src/pages/PostCreate/PostCreate.jsx
+++ b/src/pages/PostCreate/PostCreate.jsx
@@ -1,7 +1,99 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import Textarea from "../../components/Textarea/Textarea";
+import { HeaderSave } from "../../share/HeaderBind";
 
 const PostCreate = () => {
-  return <div>PostCreate</div>;
+  const myProfile = `${process.env.PUBLIC_URL}/assets/img/profile-man-small.png`;
+  const imgUpload = `${process.env.PUBLIC_URL}/assets/img/icon-upload-file.png`;
+  const imgCamcle = `${process.env.PUBLIC_URL}/assets/img/icon-x.png`;
+
+  const [images, setImages] = useState([]);
+  const [imageURLs, setImgURLs] = useState([]);
+
+  useEffect(() => {
+    if (images.length < 1 || images.length > 4) return;
+    const newImageURLs = [];
+    images.map((image) => newImageURLs.push(URL.createObjectURL(image)));
+    setImgURLs(newImageURLs);
+  }, [images]);
+
+  const handleImgUpload = (e) => {
+    setImages([...e.target.files]);
+  };
+
+  const handleImgCancle = (e) => {
+    console.log(e.target.id);
+    const newImageURLs = imageURLs.filter((_, index) => index !== parseInt(e.target.id));
+    setImgURLs(newImageURLs);
+    console.log(newImageURLs);
+    console.log(imageURLs);
+  };
+
+  return (
+    <div className="page">
+      {/* Note: Header 수정 필요 */}
+      <HeaderSave />
+      <main className="pt-[2rem] px-[1.6rem]">
+        <img src={myProfile} alt="" className="inline-block align-top w-[4.2rem] h-[4.2rem] object-cover" />
+        <form action="" className="inline-block">
+          <Textarea />
+        </form>
+        {imageURLs.length ? (
+          imageURLs.length === 1 ? (
+            <>
+              {/* key 돌 때 index 사용... */}
+              {imageURLs.map((imgURL, index) => (
+                <div key={index} className="relative">
+                  <img src={imgURL} alt="" className="w-[30.4rem] h-[22.8rem] ml-auto object-cover rounded-[10px]" />
+                  <button type="button" onClick={handleImgCancle}>
+                    <img
+                      src={imgCamcle}
+                      id={index}
+                      alt=""
+                      className="w-[2rem] h-[2rem] absolute top-[1.1rem] right-[1.1rem]"
+                    />
+                  </button>
+                </div>
+              ))}
+            </>
+          ) : (
+            <div className="flex overflow-hidden overflow-x-auto w-[30.4rem] ml-[5.4rem]">
+              {imageURLs.map((imgURL, index) => (
+                <div key={index} className="relative first:ml-0 ml-[0.8rem] shrink-0">
+                  <img
+                    // key={index}
+                    src={imgURL}
+                    alt=""
+                    className="w-[16.8rem] h-[12.6rem] object-cover rounded-[10px]"
+                  />
+                  <button type="button" onClick={handleImgCancle}>
+                    <img
+                      src={imgCamcle}
+                      id={index}
+                      alt=""
+                      className="w-[1.5rem] h-[1.5rem] absolute top-[1.1rem] right-[1.1rem]"
+                    />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )
+        ) : (
+          <></>
+        )}
+      </main>
+
+      <form className="p-[1.6rem]">
+        <fieldset>
+          <legend className="ir">사진 업로드</legend>
+          <label htmlFor="imgUpload">
+            <img src={imgUpload} alt="" className="w-[5rem] h-[5rem] ml-auto" />
+          </label>
+          <input id="imgUpload" multiple type="file" className="hidden" onChange={handleImgUpload} />
+        </fieldset>
+      </form>
+    </div>
+  );
 };
 
 export default PostCreate;


### PR DESCRIPTION
# feat: 게시글 작성 구현 - 이미지 업로드 및 텍스트 상자
#94 

## 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 : 이미지 업로드 및 텍스트 상자 크기 조절 구현 (API 연결 x)
- [x] 디자인 : 게시글 구현 마크업 및 디자인
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

-없음

## ✂️ 수정된 파일

- src/pages/PostCreate/PostCreate.jsx
- 
## 📝 생성된 파일

- src/components/Textarea/Textarea.jsx (PostCreate의 컴포넌트)

## 📢 스크린샷
<img width="472" alt="image" src="https://user-images.githubusercontent.com/103429329/208604556-72a1aba2-ab30-4aa6-a663-2763957e0760.png">

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #
