### PR TITLE
refactor: 이미지 캐러셀 px 대신 index로 관리

### DIFF
--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -3,15 +3,10 @@ import Footer from "../../share/Footer";
 import { HeaderFeed } from "../../share/HeaderBind";
 
 const Home = () => {
-  const data = [{ id: 1 }, { id: 2 }, { id: 3 }];
   return (
     <div className="page">
       <HeaderFeed />
-      <main>
-        {data.map((item) => (
-          <Post key={item.id} />
-        ))}
-      </main>
+      <main></main>
       <Footer />
     </div>
   );

--- a/src/pages/MyProfile/MyProfile.jsx
+++ b/src/pages/MyProfile/MyProfile.jsx
@@ -7,6 +7,7 @@ import Club from "../../share/Club";
 import ModalInfo from "../../components/ModalInfo/ModalInfo";
 import Modal from "../../components/Modal/Modal";
 import { useState, useCallback, useRef } from "react";
+import OtherProfile from "../OtherProfile/OtherProfile";
 const MyProfile = () => {
   const [modal, setModal] = useState(false);
   const [logout, setLogout] = useState(false);
@@ -32,7 +33,7 @@ const MyProfile = () => {
       <main>
         <UserProfile />
         <Club />
-        <Post />
+        {/* <Post /> */}
       </main>
       <Footer />
       {modal === true ? (

--- a/src/share/Post.jsx
+++ b/src/share/Post.jsx
@@ -26,27 +26,7 @@ const Post = ({ post }) => {
     modal ? setModal(false) : setModal(true);
   };
 
-  const handleButtonCarousel = (el, pos) => {
-    let currentPos = el.scrollLeft;
-    if (currentPos < pos) {
-      el.scrollLeft += pos;
-    } else if (currentPos > pos) {
-      if (pos === 0) {
-        el.scrollLeft = 0;
-      }
-      el.scrollLeft -= pos;
-    }
-    /* Carousel 버튼 색깔 변화 기능 */
-    if (el.scrollLeft === 0) {
-      setCurrentIndex(0);
-    } else if (el.scrollLeft === 304) {
-      setCurrentIndex(1);
-    } else if (el.scrollLeft === 608) {
-      setCurrentIndex(2);
-    }
-  };
-
-  // 좋아요 관리
+  // 좋아요 관리x
   const [isLike, setIsLike] = useState(post.hearted);
 
   const handleLikeBtn = () => {
@@ -95,7 +75,9 @@ const Post = ({ post }) => {
                   key={idx}
                   src={img}
                   alt=""
-                  className="min-w-full object-cover cursor-pointer"
+                  className={`min-w-full object-cover cursor-pointer ${
+                    postImg.split(", ")[currentIndex] === img ? "" : "hidden"
+                  }`}
                   onClick={handleModalToggle}
                 />
               ))}
@@ -108,11 +90,11 @@ const Post = ({ post }) => {
             <div className="relative flex justify-center -translate-y-[2rem]">
               {postImg.split(", ").map((img, idx) => (
                 <button
-                  onClick={() => handleButtonCarousel(imgRef.current, 304 * idx)}
+                  onClick={() => setCurrentIndex(postImg.split(", ").indexOf(img))}
                   key={idx}
                   id={idx}
                   className={`mr-[0.6rem] last:mr-0 text-white w-[0.6rem] h-[0.6rem] rounded-[50%] ${
-                    currentIndex === idx ? "bg-m-color" : "bg-white"
+                    postImg.split(", ")[currentIndex] === img ? "bg-m-color" : "bg-white"
                   }`}
                 ></button>
               ))}


### PR DESCRIPTION
# refactor: 이미지 캐러셀 px 대신 index로 관리
## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 디자인 : 
- [x] 리팩토링 : px 단위로 움직이던 이미지 캐러셀을 데이터의 index로 바꿨습니다.
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [x] 기타 : post 함수 변경에 따라 home과 userpofile에서 호출되던 post 함수를 제거했습니다.

## ⚠️ 삭제된 파일 

- 없음
- 
## ✂️ 수정된 파일

- src/pages/Home/Home.jsx
- src/pages/MyProfile/MyProfile.jsx
- src/share/Post.jsx
- 
## 📝 생성된 파일

- 없음

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #107 
