### PR TITLE
refactor: 데이터 1회 요청시 갯수 제한을 위해 IntersectionObserver 사용

### DIFF
--- a/src/hooks/useIntersect.jsx
+++ b/src/hooks/useIntersect.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+export default function useInterset(targetRef, stateCount, stateMore, requestAPIFunc) {
+  useEffect(() => {
+    if (!targetRef.current || !stateMore) return;
+
+    const observerCallback = (entries, observer) => {
+      if (entries[0].isIntersecting) {
+        requestAPIFunc();
+      }
+    };
+
+    const observer = new IntersectionObserver(observerCallback);
+    observer.observe(targetRef.current);
+
+    return () => observer.disconnect();
+  }, [stateCount, stateMore]);
+}

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -6,29 +6,28 @@ import axios from "../../api/axios";
 import { useEffect, useState, useRef } from "react";
 
 const Home = () => {
+  const token = localStorage.getItem("token");
   const [posts, setPosts] = useState([]);
   const [state, setState] = useState({ postNum: 0, moreFeed: true });
 
-  const observerTarget = useRef(null);
+  const getFollowersFeeds = async () => {
+    try {
+      const res = await axios.get(`/post/feed?limit=10&skip=${state.postNum}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      setPosts((prev) => [...prev, ...res.data.posts]);
+      setState((prev) => ({ postNum: prev.postNum + 10, moreFeed: posts.length % 10 === 0 }));
+    } catch (err) {
+      console.log(err);
+    }
+  };
 
-  const token = localStorage.getItem("token");
+  const observerTarget = useRef(null);
 
   useEffect(() => {
     if (!observerTarget.current || !state.moreFeed) return;
-
-    const getFollowersFeeds = async () => {
-      try {
-        const res = await axios.get(`/post/feed?limit=10&skip=${state.postNum}`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        setPosts((prev) => [...prev, ...res.data.posts]);
-        setState((prev) => ({ postNum: prev.postNum + 10, moreFeed: posts.length % 10 === 0 }));
-      } catch (err) {
-        console.log(err);
-      }
-    };
 
     const observerCallback = (entries, observer) => {
       if (entries[0].isIntersecting) {
@@ -39,10 +38,39 @@ const Home = () => {
     const observer = new IntersectionObserver(observerCallback);
     observer.observe(observerTarget.current);
 
-    return () => {
-      observer.disconnect();
-    };
-  }, [posts.length, state.postNum, state.moreFeed, token]);
+    return () => observer.disconnect();
+  }, [state]);
+
+  // useEffect(() => {
+  //   if (!observerTarget.current || !state.moreFeed) return;
+
+  //   const getFollowersFeeds = async () => {
+  //     try {
+  //       const res = await axios.get(`/post/feed?limit=10&skip=${state.postNum}`, {
+  //         headers: {
+  //           Authorization: `Bearer ${token}`,
+  //         },
+  //       });
+  //       setPosts((prev) => [...prev, ...res.data.posts]);
+  //       setState((prev) => ({ postNum: prev.postNum + 10, moreFeed: posts.length % 10 === 0 }));
+  //     } catch (err) {
+  //       console.log(err);
+  //     }
+  //   };
+
+  //   const observerCallback = (entries, observer) => {
+  //     if (entries[0].isIntersecting) {
+  //       getFollowersFeeds();
+  //     }
+  //   };
+
+  //   const observer = new IntersectionObserver(observerCallback);
+  //   observer.observe(observerTarget.current);
+
+  //   return () => {
+  //     observer.disconnect();
+  //   };
+  // }, [posts.length, state.postNum, state.moreFeed, token]);
 
   return (
     <div className="page">

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -3,34 +3,56 @@ import Post from "../../shared/Post/Post";
 import NoFeed from "../../components/NoFeed/NoFeed";
 import Footer from "../../shared/Footer/Footer";
 import axios from "../../api/axios";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 const Home = () => {
   const [posts, setPosts] = useState([]);
+  const [state, setState] = useState({ postNum: 0, moreFeed: true });
+
+  const observerTarget = useRef(null);
 
   const token = localStorage.getItem("token");
 
   useEffect(() => {
+    if (!observerTarget.current || !state.moreFeed) return;
+
     const getFollowersFeeds = async () => {
       try {
-        const res = await axios.get("/post/feed", {
+        const res = await axios.get(`/post/feed?limit=10&skip=${state.postNum}`, {
           headers: {
             Authorization: `Bearer ${token}`,
           },
         });
-        setPosts(res.data.posts);
+        setPosts((prev) => [...prev, ...res.data.posts]);
+        setState((prev) => ({ postNum: prev.postNum + 10, moreFeed: posts.length % 10 === 0 }));
       } catch (err) {
         console.log(err);
       }
     };
 
-    getFollowersFeeds();
-  }, []);
+    const observerCallback = (entries, observer) => {
+      if (entries[0].isIntersecting) {
+        getFollowersFeeds();
+      }
+    };
+
+    const observer = new IntersectionObserver(observerCallback);
+    observer.observe(observerTarget.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [posts.length, state.postNum, state.moreFeed, token]);
 
   return (
     <div className="page">
       <HeaderFeed />
-      <main>{posts.length > 0 ? posts.map((post) => <Post key={post.id} post={post} />) : <NoFeed />}</main>
+      <main>
+        <>
+          {posts.length > 0 ? posts.map((post) => <Post key={post.id} post={post} />) : <NoFeed />}
+          <div ref={observerTarget}></div>
+        </>
+      </main>
       <Footer />
     </div>
   );

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -3,7 +3,7 @@ import Post from "../../shared/Post/Post";
 import NoFeed from "../../components/NoFeed/NoFeed";
 import Footer from "../../shared/Footer/Footer";
 import axios from "../../api/axios";
-import { useEffect, useState, useRef } from "react";
+import { useState, useRef } from "react";
 import useInterset from "../../hooks/useIntersect";
 
 const Home = () => {

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -4,6 +4,7 @@ import NoFeed from "../../components/NoFeed/NoFeed";
 import Footer from "../../shared/Footer/Footer";
 import axios from "../../api/axios";
 import { useEffect, useState, useRef } from "react";
+import useInterset from "../../hooks/useIntersect";
 
 const Home = () => {
   const token = localStorage.getItem("token");
@@ -26,51 +27,7 @@ const Home = () => {
 
   const observerTarget = useRef(null);
 
-  useEffect(() => {
-    if (!observerTarget.current || !state.moreFeed) return;
-
-    const observerCallback = (entries, observer) => {
-      if (entries[0].isIntersecting) {
-        getFollowersFeeds();
-      }
-    };
-
-    const observer = new IntersectionObserver(observerCallback);
-    observer.observe(observerTarget.current);
-
-    return () => observer.disconnect();
-  }, [state]);
-
-  // useEffect(() => {
-  //   if (!observerTarget.current || !state.moreFeed) return;
-
-  //   const getFollowersFeeds = async () => {
-  //     try {
-  //       const res = await axios.get(`/post/feed?limit=10&skip=${state.postNum}`, {
-  //         headers: {
-  //           Authorization: `Bearer ${token}`,
-  //         },
-  //       });
-  //       setPosts((prev) => [...prev, ...res.data.posts]);
-  //       setState((prev) => ({ postNum: prev.postNum + 10, moreFeed: posts.length % 10 === 0 }));
-  //     } catch (err) {
-  //       console.log(err);
-  //     }
-  //   };
-
-  //   const observerCallback = (entries, observer) => {
-  //     if (entries[0].isIntersecting) {
-  //       getFollowersFeeds();
-  //     }
-  //   };
-
-  //   const observer = new IntersectionObserver(observerCallback);
-  //   observer.observe(observerTarget.current);
-
-  //   return () => {
-  //     observer.disconnect();
-  //   };
-  // }, [posts.length, state.postNum, state.moreFeed, token]);
+  useInterset(observerTarget, state.postNum, state.moreFeed, getFollowersFeeds);
 
   return (
     <div className="page">


### PR DESCRIPTION
# refactor: 데이터 1회 요청시 갯수 제한을 위해 IntersectionObserver 사용
#133

## 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 : Home 페이지 컴포넌트에 IntersectionObserver를 이용 
- [ ] 디자인 : 
- [x] 리팩토링 : 커스텀훅으로 useIntersect를 생성하여 userProfile에서도 범용적으로 사용이 가능
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/pages/Home/Home.jsx

## 📝 생성된 파일

- src/hooks/useIntersect.jsx

## 📢 스크린샷

- 최초 렌더링 시 10개의 게시글만 나타남
![image](https://user-images.githubusercontent.com/90930391/209533694-40f91c97-aecc-4478-8fd4-af191724346e.png)

- observerTarget.current 지점이 브라우저 상에 나타나면 추가로 10개의 게시글이 더 나타남
![image](https://user-images.githubusercontent.com/90930391/209533741-319d10c2-abb8-4a85-aa9d-5796b1362aef.png)

- 네트워크 통신이 이루어진 모습
![image](https://user-images.githubusercontent.com/90930391/209533804-0520f806-2e90-49af-acf3-7dc8f8f75f2d.png)


## 📌 제안 사항
- Search는 api 요청 자체에 쿼리를 추가하여 데이터의 갯수를 제한할 수 없음
- 자체적으로 데이터 렌더링에만 차이를 줄 수도 있으나 어차피 초기에 모든 데이터가 받아져 오기 때문에 사용자 경험에 있어 야기될 수 있는 불편함(약간의 버벅임?)은 개선일 불가능하다고 판단됨
- 따라서 Search 페이지 컴포넌트에서의 데이터 처리 부분은 추가로 진행하지 않았음

## 🍀 Close Issue Number
close: #133
