### PR TITLE
fix: Home 컴포넌트 내 피드가 없는 경우 observerTarget의 노출로 인한 무한 호출 버그 수정

### DIFF
--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -35,7 +35,7 @@ const Home = () => {
       <main>
         <>
           {posts.length > 0 ? posts.map((post) => <Post key={post.id} post={post} />) : <NoFeed />}
-          <div ref={observerTarget}></div>
+          {posts.length > 0 && <div ref={observerTarget}></div>}
         </>
       </main>
       <Footer />


### PR DESCRIPTION
# fix: Home 컴포넌트 내 피드가 없는 경우 observerTarget의 노출로 인한 무한 호출 버그 수정
#153

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 디자인 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : Home 컴포넌트 내 피드가 없는 경우 observerTarget의 노출로 인한 무한 호출 버그 수정
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/pages/Home/Home.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #153
