### PR TITLE
fix: Post 컴포넌트 38번째 줄 postDate 변수를 createdAt에서 updatedAt을 기준으로 변경

### DIFF
--- a/src/shared/Post/Post.jsx
+++ b/src/shared/Post/Post.jsx
@@ -35,7 +35,7 @@ const Post = ({ post }) => {
   const handleLink = () => navigate(`/profile/${post.author.accountname}`);
 
   // 날짜 정보 관리
-  const postDate = post.createdAt.slice(0, 10).replaceAll("-", "");
+  const postDate = post.updatedAt.slice(0, 10).replaceAll("-", "");
   const year = postDate.slice(0, 4);
   const month = postDate.slice(4, 6);
   const date = postDate.slice(6, 8);


### PR DESCRIPTION
# fix: Post 컴포넌트 38번째 줄 postDate 변수를 createdAt에서 updatedAt을 기준으로 변경
#177

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 디자인 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [x] 기타 : Post 컴포넌트 38번째 줄 postDate 변수를 createdAt에서 updatedAt을 기준으로 변경 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/shared/Post/Post.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #177
