### PR TITLE
fix: Home 페이지 최초 렌더링 시 10개 게시글 데이터 요청 api 동작 구동 기능 구현

### DIFF
--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -3,7 +3,7 @@ import Post from "../../shared/Post/Post";
 import NoFeed from "../../components/NoFeed/NoFeed";
 import Footer from "../../shared/Footer/Footer";
 import axios from "../../api/axios";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import useIntersect from "../../hooks/useIntersect";
 
 const Home = () => {
@@ -24,6 +24,12 @@ const Home = () => {
       console.log(err);
     }
   };
+
+  useEffect(() => {
+    if (posts.length === 0) {
+      getFollowersFeeds();
+    }
+  }, []);
 
   const observerTarget = useRef(null);
 


### PR DESCRIPTION
# fix: Home 페이지 최초 렌더링 시 10개 게시글 데이터 요청 api 동작 구동 기능 구현
#165 

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 디자인 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정
   - IntersectionObserver 적용에 따라 Home에서 팔로우하는 사람이 없을 경우, targetRef가 브라우저의 상단으로 올라와 지속적으로 api 통신을 통해 데이터를 요청하는 버그가 발생하였음.
    - 이를 해결하기 위해 게시글을 담는 배열의 길이가 0보다 클 때만 targetRef에 해당하는 div 요소를 조건부 렌더링으로 처리하였음.(관련 이슈번호: #154 )
   -  최초 렌더링시 api요청이 비동기임에 따라 게시글을 담는 배열의 크기가 0이 되는 현상이 발생함
   - 따라서 데이터 렌더링 자체가 이루어지지 않고 미구동하는 이슈가 발생하였음
   - 이를 해결하기 위해 useEffect의 두번째 인자로 빈 배열을 적용시켜 최초 렌더링시 api 요청 함수를 1회 동작시키는 코드를 추가하여 해결함
 
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/pages/Home/Home.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #165 
