### PR TITLE
feat: UserProfile 컴포넌트 버튼들 조건부 렌더링 적용 및 팔로우 여부에 따른 스타일링 작업

### DIFF
--- a/src/shared/Profile/UserProfile.jsx
+++ b/src/shared/Profile/UserProfile.jsx
@@ -44,7 +44,7 @@ const UserProfile = ({ pageProfile, follow, setFollow }) => {
             onClick={() => navigate(`/profile/${accountname}/edit`)}
             className="h-[3.4rem] mx-[1rem] btn-lg btn-cancel text-cst-gray"
           >
-            프로픨 수정
+            프로필 수정
           </button>
           <button
             type="button"

--- a/src/shared/Profile/UserProfile.jsx
+++ b/src/shared/Profile/UserProfile.jsx
@@ -45,13 +45,12 @@ const UserProfile = ({ pageProfile, follow, setFollow }) => {
       <button
         type="button"
         onClick={() => setFollow(!follow)}
-        className={`h-[3.4rem] mx-[1rem] btn-lg ${follow ? "btn-on text-white" : "btn-cancel text-cst-gray"}`}
+        className={`h-[3.4rem] mx-[1rem] btn-lg ${follow ? "btn-cancel text-cst-gray" : "btn-on text-white"}`}
       >
-        {follow ? "팔로우" : "언팔로우"}
+        {follow ? "언팔로우" : "팔로우"}
       </button>
       <button
         type="button"
-        to="/"
         className="inline-flex justify-center items-center w-[3.4rem] h-[3.4rem] border-[0.1rem] border-cst-light-gray rounded-[30px] align-bottom"
       >
         <img src={shareImg} alt="" className="w-[2rem] h-[2rem]" />

--- a/src/shared/Profile/UserProfile.jsx
+++ b/src/shared/Profile/UserProfile.jsx
@@ -36,25 +36,48 @@ const UserProfile = ({ pageProfile, follow, setFollow }) => {
       <p className="w-fit mx-auto mt-[1.6rem] text-[1.6rem] font-bold">{username}</p>
       <p className="w-fit mx-auto text-[1.2rem] text-cst-gray">@ {pageAccount}</p>
       <p className="w-fit mx-auto mt-[1.6rem] mb-[2.4rem] text-cst-gray">{intro}</p>
-      <Link
-        to="/chat"
-        className="inline-flex justify-center items-center w-[3.4rem] h-[3.4rem] border-[0.1rem] border-cst-light-gray rounded-[30px] ml-[3.6rem] align-bottom"
-      >
-        <img src={chatImg} alt="" className="w-[2rem] h-[2rem]" />
-      </Link>
-      <button
-        type="button"
-        onClick={() => setFollow(!follow)}
-        className={`h-[3.4rem] mx-[1rem] btn-lg ${follow ? "btn-cancel text-cst-gray" : "btn-on text-white"}`}
-      >
-        {follow ? "언팔로우" : "팔로우"}
-      </button>
-      <button
-        type="button"
-        className="inline-flex justify-center items-center w-[3.4rem] h-[3.4rem] border-[0.1rem] border-cst-light-gray rounded-[30px] align-bottom"
-      >
-        <img src={shareImg} alt="" className="w-[2rem] h-[2rem]" />
-      </button>
+
+      {pageAccount === accountname ? (
+        <>
+          <button
+            type="button"
+            onClick={() => navigate(`/profile/${accountname}/edit`)}
+            className="h-[3.4rem] mx-[1rem] btn-lg btn-cancel text-cst-gray"
+          >
+            프로픨 수정
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate(`/profile/${accountname}/clubupload`)}
+            className="h-[3.4rem] mx-[1rem] btn-lg btn-cancel text-cst-gray"
+          >
+            모임 만들기
+          </button>
+        </>
+      ) : (
+        <>
+          <button
+            type="button"
+            onClick={() => navigate("/chat")}
+            className="inline-flex justify-center items-center w-[3.4rem] h-[3.4rem] border-[0.1rem] border-cst-light-gray rounded-[30px] ml-[3.6rem] align-bottom"
+          >
+            <img src={chatImg} alt="" className="w-[2rem] h-[2rem]" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setFollow(!follow)}
+            className={`h-[3.4rem] mx-[1rem] btn-lg ${follow ? "btn-cancel text-cst-gray" : "btn-on text-white"}`}
+          >
+            {follow ? "언팔로우" : "팔로우"}
+          </button>
+          <button
+            type="button"
+            className="inline-flex justify-center items-center w-[3.4rem] h-[3.4rem] border-[0.1rem] border-cst-light-gray rounded-[30px] align-bottom"
+          >
+            <img src={shareImg} alt="" className="w-[2rem] h-[2rem]" />
+          </button>
+        </>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
# feat: UserProfile 컴포넌트 버튼들 조건부 렌더링 적용 및 팔로우 여부에 따른 스타일링 작업
#176 

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 사용자의 프로필 페이지인 경우 "프로필 수정"과 "모임 만들기" 버튼이 렌더링 되도록 함
- [x] 디자인 : 팔로우된 사용자에 대해서는 "언팔로우", 팔로우 되지 않은 사용자에 대해서는 "팔로우" 텍스트 및 스타일이 적용되도록 함 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/shared/Profile/UserProfile.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

- 사용자 본인의 프로필 페이지인 경우
![image](https://user-images.githubusercontent.com/90930391/209892775-9080eb90-8a70-445c-8918-93dce876d6f0.png)

- 타인의 프로필 페이지인 경우
![image](https://user-images.githubusercontent.com/90930391/209892802-db00b9e3-fd63-47e5-af82-5dca7fa216d3.png)


## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #176
