### PR TITLE
feat: handleArrowBtnVisibility 함수 생성 및 Club 스크롤 버튼 UI, UX 수정

### DIFF
--- a/src/shared/UserClub/UserClub.jsx
+++ b/src/shared/UserClub/UserClub.jsx
@@ -1,12 +1,12 @@
-import { useRef, useState } from "react";
+import { useState, useRef } from "react";
 import SimpleClub from "../../components/SimpleClub/SimpleClub";
 
 const UserClub = ({ club }) => {
-  /* Note: 실제로 API를 통해 받아오는 데이터는 다를 수 있습니다. */
-  /* Note: 데이터가 없는 경우 즉 참여하는 클럽이 없을 경우에 대한 예외처리가 필요합니다. */
-  /* scroll Button 기능을 구현하기 위해 사용된 코드입니다. */
-  const elRef = useRef(null);
-  const [arrowDisabled, setArrowDisabled] = useState(true);
+  const ulRef = useRef(null);
+  const btnRef = useRef([]);
+  // const [btnClickCount, setBtnClickCount] = useState(0);
+  const [leftBtnVisible, setLeftBtnVisible] = useState(false);
+  const [rightBtnVisible, setRightBtnVisible] = useState(true);
 
   const handleHorizontalScroll = (el, speed, distance, step) => {
     let scrollAmount = 0;
@@ -16,18 +16,35 @@ const UserClub = ({ club }) => {
       if (scrollAmount >= distance) {
         clearInterval(slideTimer);
       }
-      if (el.scrollLeft === 0) {
-        setArrowDisabled(true);
-      } else {
-        setArrowDisabled(false);
-      }
     }, speed);
+  };
+
+  function scrollLeftValue(el) {
+    console.log("--------");
+    console.log(el.scrollLeft);
+    console.log(el.scrollWidth);
+    console.log(el.clientWidth);
+    console.log(el.scrollWidth - el.clientWidth - 2);
+  }
+
+  const handleArrowBtnVisibility = (currentPosX) => {
+    console.log(currentPosX);
+    if (currentPosX === 0) {
+      console.log(currentPosX);
+    } else if (currentPosX >= ulRef.current.scrollWidth - (ulRef.current.clientWidth + 2)) {
+      setRightBtnVisible(false);
+      console.log(currentPosX);
+    } else if (currentPosX > 0 && currentPosX < ulRef.current.scrollWidth - (ulRef.current.clientWidth + 2)) {
+      setLeftBtnVisible(true);
+      setRightBtnVisible(true);
+      console.log(currentPosX);
+    }
   };
 
   return (
     <section className="relative px-[1.6rem] py-[2rem]">
       <h2 className="mb-[1.6rem]">참여 중인 산책</h2>
-      <ul className="flex flex-row overflow-hidden overflow-x-scroll scrollbar-hide" ref={elRef}>
+      <ul className="flex flex-row overflow-hidden overflow-x-scroll scrollbar-hide" ref={ulRef}>
         {club.length > 0 ? (
           club.map((item) => <SimpleClub key={item.id} data={item} />)
         ) : (
@@ -37,19 +54,32 @@ const UserClub = ({ club }) => {
       {club.length > 0 && (
         <div className="relative top-[-9rem] flex justify-between w-full">
           <button
-            className="absolute z-10 left-[-1rem] bg-[#0000005d] leading-[100%] w-[3rem] h-[3rem] text-[3rem] text-[#ffffff9a] rounded-[50%] cursor-pointer"
+            className={`absolute z-10 left-[-1rem] ${
+              leftBtnVisible ? "visible" : "hidden"
+            } bg-[#0000005d] leading-[100%] w-[3rem] h-[3rem] text-[3rem] text-[#ffffff9a] rounded-[50%] cursor-pointer`}
             type="button"
             aria-label="prev"
-            onClick={() => handleHorizontalScroll(elRef.current, 25, 140, -10)}
-            disabled={arrowDisabled}
+            ref={(el) => (btnRef.current[0] = el)}
+            onClick={() => {
+              handleHorizontalScroll(ulRef.current, 25, 150, -10);
+              handleArrowBtnVisibility(ulRef.current.scrollLeft - 150);
+            }}
           >
             &lt;
           </button>
           <button
-            className="absolute z-10 right-[-1rem] bg-[#0000005d] leading-[100%] w-[3rem] h-[3rem] text-[3rem] text-[#ffffff9a] rounded-[50%] cursor-pointer"
+            className={`absolute z-10 right-[-1rem] ${
+              rightBtnVisible ? "visible" : "hidden"
+            } bg-[#0000005d] leading-[100%] w-[3rem] h-[3rem] text-[3rem] text-[#ffffff9a] rounded-[50%] cursor-pointe`}
             type="button"
             aria-label="next"
-            onClick={() => handleHorizontalScroll(elRef.current, 25, 140, 10)}
+            ref={(el) => (btnRef.current[1] = el)}
+            onClick={() => {
+              handleHorizontalScroll(ulRef.current, 25, 150, 10);
+              handleArrowBtnVisibility(ulRef.current.scrollLeft + 150);
+              /* temp */
+              scrollLeftValue(ulRef.current);
+            }}
           >
             &gt;
           </button>

--- a/src/shared/UserClub/UserClub.jsx
+++ b/src/shared/UserClub/UserClub.jsx
@@ -19,7 +19,8 @@ const UserClub = ({ club }) => {
   };
 
   const handleArrowBtnVisibility = (currentPosX) => {
-    if (currentPosX === 0) {
+    if (currentPosX <= 0) {
+      setLeftBtnVisible(false);
     } else if (currentPosX >= ulRef.current.scrollWidth - (ulRef.current.clientWidth + 2)) {
       setRightBtnVisible(false);
     } else if (currentPosX > 0 && currentPosX < ulRef.current.scrollWidth - (ulRef.current.clientWidth + 2)) {

--- a/src/shared/UserClub/UserClub.jsx
+++ b/src/shared/UserClub/UserClub.jsx
@@ -4,7 +4,6 @@ import SimpleClub from "../../components/SimpleClub/SimpleClub";
 const UserClub = ({ club }) => {
   const ulRef = useRef(null);
   const btnRef = useRef([]);
-  // const [btnClickCount, setBtnClickCount] = useState(0);
   const [leftBtnVisible, setLeftBtnVisible] = useState(false);
   const [rightBtnVisible, setRightBtnVisible] = useState(true);
 
@@ -19,25 +18,13 @@ const UserClub = ({ club }) => {
     }, speed);
   };
 
-  function scrollLeftValue(el) {
-    console.log("--------");
-    console.log(el.scrollLeft);
-    console.log(el.scrollWidth);
-    console.log(el.clientWidth);
-    console.log(el.scrollWidth - el.clientWidth - 2);
-  }
-
   const handleArrowBtnVisibility = (currentPosX) => {
-    console.log(currentPosX);
     if (currentPosX === 0) {
-      console.log(currentPosX);
     } else if (currentPosX >= ulRef.current.scrollWidth - (ulRef.current.clientWidth + 2)) {
       setRightBtnVisible(false);
-      console.log(currentPosX);
     } else if (currentPosX > 0 && currentPosX < ulRef.current.scrollWidth - (ulRef.current.clientWidth + 2)) {
       setLeftBtnVisible(true);
       setRightBtnVisible(true);
-      console.log(currentPosX);
     }
   };
 
@@ -77,8 +64,6 @@ const UserClub = ({ club }) => {
             onClick={() => {
               handleHorizontalScroll(ulRef.current, 25, 150, 10);
               handleArrowBtnVisibility(ulRef.current.scrollLeft + 150);
-              /* temp */
-              scrollLeftValue(ulRef.current);
             }}
           >
             &gt;


### PR DESCRIPTION
# feat: handleArrowBtnVisibility 함수 생성 및 Club 스크롤 버튼 UI, UX 수정
#119

## 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 : 
   - 좌우 스크롤 버튼 클릭 시 이동하는 길이를 콘텐츠 크기인 140px에서  li의 margin-right 10px을 포함한 길이 150px로 수정
   - 좌우 버튼을 btnRef 변수의 배열 요소로 컨트롤
- [x] 디자인 : 
   - 최초 렌더링 시에는 왼쪽 버튼을 visibility: hidden으로 숨김 처리
   - 오른쪽 버튼 클릭 시 ul 요소의 scrollLeft 값을 150px 이동 시킴
   - ul의 마지막 li 요소에 도달 시 오른쪽 버튼 숨김 처리
   - 오른쪽으로 이동 후 다시 ul의 첫번째 li요소에 도달 시 왼쪽 버튼 숨김 처리
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/shared/UserClub/UserClub.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

- 스크롤 이벤트 발생시 scrollLeft의 값을 콘솔로 확인하는 과정을 포함하는 이미지 입니다.

![image](https://user-images.githubusercontent.com/90930391/209906960-80635f74-30f9-4735-b214-ba8892bfdaa8.png)

![image](https://user-images.githubusercontent.com/90930391/209906970-a0afefda-12fb-457a-94e8-9d58bb710c1c.png)

![image](https://user-images.githubusercontent.com/90930391/209906979-849f363c-55ce-43a2-8389-9f8ac3b28d7f.png)


## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #119
