### PR TITLE
feat: chat페이지 더미데이터로 구현

### DIFF
--- a/src/components/ChatDummyData/ChatDummyData.jsx
+++ b/src/components/ChatDummyData/ChatDummyData.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+const ChatDummyData = () => {
+  const basicImg = `${process.env.PUBLIC_URL}/assets/img/profile-woman-small.png`;
+  const basicImg2 = `${process.env.PUBLIC_URL}/assets/img/char-404-cat.svg`;
+  const basicImg3 = `${process.env.PUBLIC_URL}/assets/img/char-default-cat.svg`;
+  const basicImg4 = `${process.env.PUBLIC_URL}/assets/img/char-login-cat.svg`;
+  const basicImg5 = `${process.env.PUBLIC_URL}/assets/img/profile-man-small.png`;
+
+  const navigate = useNavigate();
+
+  const userData = [
+    {
+      id: "0",
+      username: "애니멀 걸",
+      profileImage: basicImg,
+      accountname: "animalgirl",
+      text: "저녁 뭐 먹을까?",
+      time: "2022.12.25",
+    },
+    {
+      id: "1",
+      username: "주황 고양이",
+      profileImage: basicImg3,
+      accountname: "orangecat",
+      text: "취업 준비는 잘 되어가? 사료 떨어졌어 사와",
+      time: "2022.12.23",
+    },
+    {
+      id: "2",
+      username: "애니멀 맨",
+      profileImage: basicImg5,
+      accountname: "animalman",
+      text: "프로젝트 잘하고 있니?..",
+      time: "2022.12.16",
+    },
+    {
+      id: "3",
+      username: "404 고양이",
+      profileImage: basicImg2,
+      accountname: "404cat",
+      text: "올때 츄르 한 박스 사와",
+      time: "2022.12.03",
+    },
+    {
+      id: "4",
+      username: "컬러풀 고양이",
+      profileImage: basicImg4,
+      accountname: "colorfulcat",
+      text: "크리스마스에 영화보러 갈래?..",
+      time: "2022.12.02",
+    },
+  ];
+
+  const handleChatRoom = (e) => {
+    navigate(`/chat/${e.currentTarget.dataset.value}`);
+  };
+
+  return (
+    <>
+      {userData.map((item) => (
+        <li
+          data-value={item.accountname}
+          onClick={handleChatRoom}
+          key={item.id}
+          className="relative mx-[1.6rem] my-[1.6rem] flex justify-between items-center cursor-pointer"
+        >
+          <img src={item.profileImage} alt="" className="w-[5rem] h-[5rem] rounded-[50%]" />
+          <p className="mr-auto ml-[1.2rem]">
+            <strong className="font-medium">{item.username}</strong>
+            <span className="block text-[1.2rem] w-[23.8rem] whitespace-nowrap text-cst-gray text-ellipsis overflow-hidden">
+              {item.text}
+            </span>
+          </p>
+          <time dateTime="2022-12-21" className="mt-[2.3rem] text-[1rem] text-cst-light-gray">
+            {item.time}
+          </time>
+        </li>
+      ))}
+    </>
+  );
+};
+
+export default ChatDummyData;

--- a/src/pages/ChatList/ChatList.jsx
+++ b/src/pages/ChatList/ChatList.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Footer from "../../shared/Footer/Footer";
 import { HeaderBasic } from "../../shared/Header/HeaderBasic";
 import SimpleUserList from "../../shared/SimpleUserList/SimpleUserList";
+import ChatDummyData from "../../components/ChatDummyData/ChatDummyData";
 
 const Chat = () => {
   return (
@@ -9,10 +10,7 @@ const Chat = () => {
       <HeaderBasic />
       <main>
         <ul className="mt-[2rem]">
-          <SimpleUserList isBtn={false} />
-          <SimpleUserList isBtn={false} />
-          <SimpleUserList isBtn={false} />
-          <SimpleUserList isBtn={false} />
+          <ChatDummyData />
         </ul>
       </main>
       <Footer />


### PR DESCRIPTION
# feat: chat페이지 더미데이터로 구현

## 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 : chat페이지에 더미데이터 삽입하여 실제 대화창처럼 구현
- [ ] 디자인 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 삭제된 파일의 경로를 적어주세요
- 없음

## ✂️ 수정된 파일

- 수정된 파일의 경로를 적어주세요
- src/pages/ChatList/ChatList.jsx

## 📝 생성된 파일

- 생성된 파일의 경로를 적어주세요
- src/components/ChatDummyData/ChatDummyData.jsx

## 📢 스크린샷

![image](https://user-images.githubusercontent.com/68059880/209908655-8700ee45-8e81-423a-bf28-5b158976bed1.png)

chatDummyData.jsx에 userData를 만들어 map으로 화면에 렌더링해주었습니다

![image](https://user-images.githubusercontent.com/68059880/209908728-12fe0259-d2f9-42c3-989d-a1d23f8ccbdd.png)

data- 속성을 활용하여 accountname에따라 url이 이동되게 하였습니다.

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #186 
