### PR TITLE
feat: 불러오지 못하는 이미지 기본이미지로 대체

### DIFF
--- a/src/shared/Profile/UserProfile.jsx
+++ b/src/shared/Profile/UserProfile.jsx
@@ -5,6 +5,7 @@ import { UserContext } from "../../context/UserContext";
 const UserProfile = ({ pageProfile, follow, setFollow }) => {
   const chatImg = `${process.env.PUBLIC_URL}/assets/img/icon-message-circle-line-profile.png`;
   const shareImg = `${process.env.PUBLIC_URL}/assets/img/icon-share.png`;
+  const defaultProfile = `${process.env.PUBLIC_URL}/assets/img/profile-woman-large.png`;
 
   const profileImg = pageProfile.image;
   const followers = pageProfile.followerCount;
@@ -26,7 +27,14 @@ const UserProfile = ({ pageProfile, follow, setFollow }) => {
           followers
         </button>
       </Link>
-      <img src={profileImg} alt="" className="inline-block w-[11rem] h-[11rem] ml-[4.3rem] mr-[3.6rem]" />
+      <img
+        onError={(e) => {
+          e.target.src = defaultProfile;
+        }}
+        src={profileImg}
+        alt=""
+        className="inline-block w-[11rem] h-[11rem] ml-[4.3rem] mr-[3.6rem] rounded-[50%]"
+      />
       <Link to={`/profile/${pageAccount}/followings`} className="inline-block">
         <button type="button" className="text-[1rem] text-cst-gray">
           <span className="block text-[1.8rem] font-bold text-black">{followings}</span>

--- a/src/shared/SimpleUserList/SimpleUserList.jsx
+++ b/src/shared/SimpleUserList/SimpleUserList.jsx
@@ -6,6 +6,7 @@ const SimpleUserList = ({ isMessage, isBtn, isChatMode, username, accountname, p
   // Note:: 실제로는 nullish가 아니라 props를 사용해 컨트롤할 수 있습니다.
   const content = null;
   const chat = isChatMode && "안녕하세요. 가나다라마바사아자카타파하아";
+  const defaultProfile = `${process.env.PUBLIC_URL}/assets/img/profile-woman-large.png`;
 
   // 채팅리스트에서만 사용됩니다. 읽지 않은 메시지 알람을 관립합니다.
   // const message = true;
@@ -41,6 +42,9 @@ const SimpleUserList = ({ isMessage, isBtn, isChatMode, username, accountname, p
         alt=""
         className="w-[5rem] h-[5rem] cursor-pointer rounded-[50%]"
         onClick={handleLink}
+        onError={(e) => {
+          e.target.src = defaultProfile;
+        }}
       />
       <p className="mr-auto ml-[1.2rem] cursor-pointer" onClick={handleLink}>
         <strong className="font-medium">{username}</strong>


### PR DESCRIPTION
# feat: 불러오지 못하는 이미지 기본이미지로 대체

## 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 : 검색, 유저프로필 정보를 볼 때 서버에서 이미지를 제대로 불러오지 못할 때 엑박이나는 경우 애니멀 톡의 기본 여자이미지로 대체할 수 있도록 수정하였습니다.
- [ ] 디자인 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 삭제된 파일의 경로를 적어주세요
- 없음

## ✂️ 수정된 파일

- 수정된 파일의 경로를 적어주세요
- src/shared/Profile/UserProfile.jsx
- src/shared/SimpleUserList/SimpleUserList.jsx

## 📝 생성된 파일

- 생성된 파일의 경로를 적어주세요
- 없음

## 📢 스크린샷
![image](https://user-images.githubusercontent.com/68059880/209917332-bef01c84-6e65-44c1-a821-4efb7f68b6f3.png)
![image](https://user-images.githubusercontent.com/68059880/209917432-2b92cd8a-b219-4777-b294-34215d6a4f3a.png)

기존에는 위와 같이 엑박이 났었습니다.

![image](https://user-images.githubusercontent.com/68059880/209917483-12e3a7be-9f64-4ea3-9273-37e13852af3a.png)

![image](https://user-images.githubusercontent.com/68059880/209917517-25accf32-212e-43a7-bf62-930093fc7a92.png)

수정후의 모습입니다
## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #193 
