### PR TITLE
fix: postDataArr useState 초깃값 빈 배열 할당에 따른 로딩 지연 조건부 렌더링 삭제

### DIFF
--- a/src/pages/UserFeed/UserFeed.jsx
+++ b/src/pages/UserFeed/UserFeed.jsx
@@ -131,7 +131,7 @@ const UserFeed = () => {
             <PostTypeSelectBar list={list} onListToggle={onListToggle} />
             <section>
               <h2 className="ir">유저 게시글</h2>
-              {postDataArray && !postDataArray.length && (
+              {!postDataArray.length && (
                 <>
                   <img
                     src={loadingImg}
@@ -153,16 +153,7 @@ const UserFeed = () => {
                   </section>
                 )
               ) : (
-                <>
-                  {/*                   <img
-                    src={loadingImg}
-                    alt="잠시만 기다려 주세요."
-                    className="inline-block ml-[2.9rem] w-[4rem] h-[4rem] mt-[2rem] animate-pulse"
-                  />
-                  <p className="inline-block align-[-1.2rem] ml-[0.5rem] text-m-color">
-                    로딩중입니다. 잠시만 기다려주세요.
-                  </p> */}
-                </>
+                <></>
               )}
               {postDataArray.length > 0 && <div ref={observerTarget} className="h-[0.1rem]"></div>}
             </section>


### PR DESCRIPTION
# fix: postDataArr useState 초깃값 빈 배열 할당에 따른 로딩 지연 조건부 렌더링 삭제
#222

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 디자인 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [x] 기타 : 
   - postDataArr의 초깃값을 null로 설정하였던 것에서 observeIntersect에 의한 데이터 api 요청 처리를 위해 빈배열로 변경하였습니다.
   - null로 할당함에 따라 최초 렌더링 시점에 발생할 수 있는 에러 (초깃값이 null 임에 따라 postDataArr.length 등은 읽을 수 없는 값에 대한 에러가 발생합니다)를 해결하기 위해 loading 조건부 렌더링을 추가하였습니다.
   - 하지만 빈배열로 초깃값을 변경하였기 때문에 loading 조건부 렌더링이 불필요합니다.
   - 따라서 해당 부분을 제거하게 되었습니다.

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/pages/UserFeed/UserFeed.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #222
