### PR TITLE
design: 리스트형, 앨범형 버튼 좌우 간격 16px margin 적용

### DIFF
--- a/src/components/PostTypeSelectBar/PostTypeSelectBar.jsx
+++ b/src/components/PostTypeSelectBar/PostTypeSelectBar.jsx
@@ -11,7 +11,7 @@ const PostTypeSelectBar = ({ list, onListToggle }) => {
       <button className="w-[2.6rem] h-[2.6rem]" type="button" aria-label="리스트형" onClick={onListToggle}>
         <img src={list ? postListOn : postListOff} alt="" />
       </button>
-      <button className="w-[2.6rem] h-[2.6rem]" type="button" aria-label="앨범형" onClick={onListToggle}>
+      <button className="w-[2.6rem] h-[2.6rem] ml-[1.6rem]" type="button" aria-label="앨범형" onClick={onListToggle}>
         <img src={list ? postAlbumOff : postAlbumOn} alt="" />
       </button>
     </div>


### PR DESCRIPTION
# design: 리스트형, 앨범형 버튼 좌우 간격 16px margin 적용\
#228

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [x] 디자인 : 리스트형, 앨범형 버튼 좌우 간격 16px margin 적용
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/components/PostTypeSelectBar/PostTypeSelectBar.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

![image](https://user-images.githubusercontent.com/90930391/210221732-7f645a66-2749-4ded-a50d-56ec95742975.png)


## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #228
