### PR TITLE
bug: 게시글의 이미지인 post.image가 undefined인 경우 Cannot read properties of un…

### DIFF
--- a/src/shared/Post/Post.jsx
+++ b/src/shared/Post/Post.jsx
@@ -16,7 +16,7 @@ const Post = ({ post, setIsUpload }) => {
   const commentImg = `${process.env.PUBLIC_URL}/assets/img/icon-message-circle-line-profile.png`;
 
   // 포스트 이미지 및 모달 처리
-  const postImg = !!post.image.split(",")[0] ? post.image : null;
+  const postImg = post.image && !!post.image.split(",")[0] ? post.image : null;
   const imgRef = useRef(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [modalPostImg, setModalPostImg] = useState(false);


### PR DESCRIPTION
# bug: 게시글의 이미지인 post.image가 undefined인 경우 Cannot read properties of undefined 에러 해결을 위한 수정
#225

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 디자인 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : 게시글의 이미지인 post.image가 undefined인 경우 Cannot read properties of undefined 에러 해결을 위한 수정
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/shared/Post/Post.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

- 버그

![image](https://user-images.githubusercontent.com/90930391/210222254-74cd16d7-49bf-4097-964f-58ced4a20270.png)


## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #225
