### PR TITLE
refactor: 리스트형, 앨범형 삼항연산자 중복 사용으로 인한 코드 가독성 문제 해결

### DIFF
--- a/src/pages/UserFeed/UserFeed.jsx
+++ b/src/pages/UserFeed/UserFeed.jsx
@@ -147,19 +147,16 @@ const UserFeed = () => {
                   <p className="text-[1.6rem] text-center text-m-color">작성된 게시글이 없어요...ㅠㅠ</p>
                 </>
               )}
-              {postDataArray.length > 0 ? (
-                list ? (
-                  postDataArray.map((post) => <Post key={post.id} {...{ post }} {...{ setIsUpload }} />)
-                ) : (
-                  <section className="flex flex-wrap gap-[0.8rem] my-[1.6rem] mx-[1.6rem]">
-                    <h2 className="ir">앨범형</h2>
-                    {postDataArray.map((post) => (
-                      <PostAlbum key={post.id} post={post} />
-                    ))}
-                  </section>
-                )
+              {postDataArray.length === 0 && <></>}
+              {postDataArray.length > 0 && list ? (
+                postDataArray.map((post) => <Post key={post.id} {...{ post }} {...{ setIsUpload }} />)
               ) : (
-                <></>
+                <section className="flex flex-wrap gap-[0.8rem] my-[1.6rem] mx-[1.6rem]">
+                  <h2 className="ir">앨범형</h2>
+                  {postDataArray.map((post) => (
+                    <PostAlbum key={post.id} post={post} />
+                  ))}
+                </section>
               )}
               {postDataArray.length > 0 && <div ref={observerTarget} className="h-[0.1rem]"></div>}
             </section>


### PR DESCRIPTION
# refactor: 리스트형, 앨범형 삼항연산자 중복 사용으로 인한 코드 가독성 문제 해결
#240

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 디자인 : 
- [x] 리팩토링 : 리스트형 앨범형을 list로 컨트롤 함에 있어 발생한 이중 삼항연산자 사용을 지양하기 위해 코드를 개선시켰습니다.
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/pages/UserFeed/UserFeed.jsx

## 📝 생성된 파일

- 없음

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number
close: #240
