### PR TITLE
refactor: Home 페이지에서와 프로필 페이지에서의 NoFeed 처리 구분

### DIFF
--- a/src/components/NoFeed/NoFeed.jsx
+++ b/src/components/NoFeed/NoFeed.jsx
@@ -1,12 +1,18 @@
 import React from "react";
-import { useNavigate } from "react-router-dom/dist";
+import { useNavigate, useParams } from "react-router-dom/dist";
 
 const NoFeed = () => {
   const defaultImg = `${process.env.PUBLIC_URL}/assets/img/char-default-cat.svg`;
 
+  const { accountname } = useParams();
   const navigate = useNavigate();
 
-  return (
+  return accountname ? (
+    <>
+      <img src={defaultImg} alt="노트북을 들고 있는 고양이" className="mx-[auto] mt-[25%] mb-[3rem]" />
+      <p className="text-[1.6rem] text-center text-m-color">작성된 게시글이 없어요...ㅠㅠ</p>
+    </>
+  ) : (
     <section className="h-full my-auto flex flex-col justify-center items-center">
       <h2 className="ir">유저를 검색해주세요.</h2>
       <img src={defaultImg} alt="팔로우하는 유저가 없습니다." className="w-[14.5rem] h-[20rem] align-bottom" />


### PR DESCRIPTION
# refactor: Home 페이지에서와 프로필 페이지에서의 NoFeed 처리 구분

## 🍀 무엇을 위한 PR인가요?

- [ ] 기능 추가 :
- [x] 디자인 : Home 페이지에서와 프로필 페이지에서의 NoFeed 처리 구분
- [ ] 리팩토링 : 
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 테스트 :
- [ ] 기타 :

## ⚠️ 삭제된 파일

-

## ✂️ 수정된 파일

- src/components/NoFeed/NoFeed.jsx

## 📝 생성된 파일

-

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number

close: #397
