### PR TITLE
design: PostAlbum의 레이아웃 디자인을 별도의 Outline 컴포넌트에서 도입하여 Post 컴포넌트의 코드 개선

### DIFF
--- a/src/shared/Post/PostAlbumOutline.jsx
+++ b/src/shared/Post/PostAlbumOutline.jsx
@@ -1,0 +1,13 @@
+import { v4 as uuidv4 } from "uuid";
+import PostAlbum from "./PostAlbum";
+
+export const PostAlbumOutline = ({ results }) => {
+  return (
+    <section className="sm:grid sm:grid-cols-3 sm:gap-[0.8rem] my-[1.6rem] mx-[2rem]">
+      <h2 className="ir">앨범형</h2>
+      {results.map((post) => (
+        <PostAlbum key={post.id + uuidv4()} post={post} />
+      ))}
+    </section>
+  );
+};


### PR DESCRIPTION
# design: PostAlbum의 레이아웃 디자인을 별도의 Outline 컴포넌트에서 도입하여 Post 컴포넌트의 코드 가독성 향상

## 🍀 무엇을 위한 PR인가요?

- [ ] 기능 추가 :
- [x] 디자인 : PostAlbum의 레이아웃 디자인을 별도의 Outline 컴포넌트에서 도입하여 Post 컴포넌트의 코드 가독성 향상
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 테스트 :
- [ ] 기타 :

## ⚠️ 삭제된 파일

-

## ✂️ 수정된 파일

-

## 📝 생성된 파일

- src/shared/Post/PostAlbumOutline.jsx

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number

close: #394
