### PR TITLE
fix: skip을 10의 배수로 설정하여 데이터 요청의 중복을 제거

### DIFF
--- a/src/api/axios.jsx
+++ b/src/api/axios.jsx
@@ -17,9 +17,9 @@ export const axiosImgUpload = axios.create({
 });
 
 // Home
-export const getFollowersFeeds = async (pageParam = 1, token, options = {}) => {
+export const getFollowersFeeds = async (pageParam = 0, token, options = {}) => {
   const res = await api.get(
-    `/post/feed?limit=10&skip=${pageParam}`,
+    `/post/feed?limit=10&skip=${pageParam * 10}`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -50,9 +50,9 @@ export const getPageOwnerProfile = async (pageAccount, token) => {
   return res.data.profile;
 };
 
-export const getPageOwnerFeeds = async (pageAccount, pageParam = 1, token, options = {}) => {
+export const getPageOwnerFeeds = async (pageAccount, pageParam = 0, token, options = {}) => {
   const res = await api.get(
-    `/post/${pageAccount}/userpost/?limit=10&skip=${pageParam}`,
+    `/post/${pageAccount}/userpost/?limit=10&skip=${pageParam * 10}`,
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/hooks/useFeeds.jsx
+++ b/src/hooks/useFeeds.jsx
@@ -25,7 +25,7 @@ export default function useFeeds(pageNum = 1) {
           ? await getPageOwnerFeeds(accountname, pageNum, token, { signal })
           : await getFollowersFeeds(pageNum, token, { signal });
         setResults((prev) => [...prev, ...res]);
-        setHasMore(!Boolean(res.length % 10));
+        setHasMore(Boolean(res.length));
         setIsLoading(false);
       } catch (err) {
         setIsLoading(false);

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -8,7 +8,7 @@ import useFeeds from "../../hooks/useFeeds";
 import { v4 as uuidv4 } from "uuid";
 
 const Home = () => {
-  const [pageNum, setPageNum] = useState(1);
+  const [pageNum, setPageNum] = useState(0);
   const { results, isLoading, isError, error, hasMore } = useFeeds(pageNum);
   const observerTarget = useRef(null);
   const lastFeedRef = useCallback(

--- a/src/pages/UserFeed/UserFeed.jsx
+++ b/src/pages/UserFeed/UserFeed.jsx
@@ -35,7 +35,7 @@ const UserFeed = () => {
   const [club, setClub] = useState(null);
 
   // 피드 정보 무한스크롤 기능 구현
-  const [pageNum, setPageNum] = useState(1);
+  const [pageNum, setPageNum] = useState(0);
   const { results, isLoading, isError, error, hasMore } = useFeeds(pageNum);
   const observerTarget = useRef(null);
 


### PR DESCRIPTION
# fix: skip을 10의 배수로 설정하여 데이터 요청의 중복을 제거

## 🍀 무엇을 위한 PR인가요?

- [ ] 기능 추가 :
- [ ] 디자인 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : skip을 10의 배수로 설정하여 데이터 요청의 중복을 제거
- [ ] 테스트 :
- [ ] 기타 :

## ⚠️ 삭제된 파일

-

## ✂️ 수정된 파일

- src/api/axios.jsx
- src/hooks/useFeeds.jsx
- src/pages/Home/Home.jsx
- src/pages/UserFeed/UserFeed.jsx

## 📝 생성된 파일

-

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number

close: #405
