### PR TITLE
fix: readFollowingFeed, readMyFeed api 통신시 skip 갯수 10개로 조정

### DIFF
--- a/src/api/Feed/readFollowingFeed.ts
+++ b/src/api/Feed/readFollowingFeed.ts
@@ -1,6 +1,8 @@
 import { accessInstance } from "../axios";
 
 export const readFollowingFeed = async (feedParam: number) => {
-  const data = await accessInstance.get<any, any>(`/post/feed?limit=20&skip=${feedParam * 20}`);
+  console.log(feedParam);
+
+  const data = await accessInstance.get<any, any>(`/post/feed?limit=20&skip=${feedParam * 10}`);
   return data.posts;
 };

--- a/src/api/Feed/readMyFeed.ts
+++ b/src/api/Feed/readMyFeed.ts
@@ -1,6 +1,6 @@
 import { accessInstance } from "../axios";
 
 export const readMyFeed = async (pageAccount: string, feedParam: number) => {
-  const data = await accessInstance.get<any, any>(`/post/${pageAccount}/userpost/?limit=20&skip=${feedParam * 20}`);
+  const data = await accessInstance.get<any, any>(`/post/${pageAccount}/userpost/?limit=20&skip=${feedParam * 10}`);
   return data.post;
 };


### PR DESCRIPTION
# fix: readFollowingFeed, readMyFeed api 통신시 skip 갯수 10개로 조정

## 🍀 무엇을 위한 PR인가요?

- [ ] 기능 추가 :
- [ ] 디자인 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : readFollowingFeed, readMyFeed api 통신시 skip 갯수 10개로 조정
- [ ] 마이그레이션 :
- [ ] 테스트 :
- [ ] 기타 :

## ⚠️ 삭제된 파일

-

## ✂️ 수정된 파일

- src/api/Feed/readFollowingFeed.ts
- src/api/Feed/readMyFeed.ts

## 📝 생성된 파일

-

## 📢 스크린샷

## 📌 제안 사항

- [링크](이슈 링크 달아주세요)

## 🍀 Close Issue Number

close: #457
